### PR TITLE
fix: add missing comma

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -20,7 +20,7 @@
                url-prefix("https://invidious.esmailelbob.xyz"),
                url-prefix("https://invidious.flokinet.to"),
                url-prefix("https://invidious.kavin.rocks"),
-               url-prefix("https://invidious.namazso.eu")
+               url-prefix("https://invidious.namazso.eu"),
                url-prefix("https://invidious.nerdvpn.de"),
                url-prefix("https://invidious.projectsegfau.lt"),
                url-prefix("https://invidious.rhyshl.live"),


### PR DESCRIPTION
Add the missing comma in the `@-moz-document` URL list.
It was causing a parse error while trying to install with Stylus.